### PR TITLE
allow adding of arbitrary container env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To use this role three variables should be set for the storage location and key/
     minio_podman_data_dir: /srv/minio
     minio_podman_key: CHANGEME
     minio_podman_secret: CHANGEMECHANGEME
+    minio_podman_env:
+      - MINIO_REGION_NAME=us-east-1
 
 Additional variables with their defaults can be found in `defaults/main.yml`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,4 @@ minio_podman_unit_file: "{{ minio_podman_systemd_directory }}/{{ minio_podman_se
 minio_podman_data_dir: /srv/minio
 minio_podman_key: CHANGEME
 minio_podman_secret: CHANGEMECHANGEME
+minio_podman_env: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,6 +13,7 @@
     podman run -d -p '{{ minio_podman_external_port }}':9000 --name '{{ minio_podman_container_name }}'
     -e "MINIO_ACCESS_KEY={{ minio_podman_key }}"
     -e "MINIO_SECRET_KEY={{ minio_podman_secret }}"
+    {{ minio_podman_env_args }}
     -v '{{ minio_podman_data_dir }}:/data:Z'
     "{{ minio_podman_image_name }}" server /data
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # tasks file for smlloyd.minio_podman
 
+- name: Compile container environment variables
+  set_fact:
+    minio_podman_env_args: '-e "{{ item }}" {{ minio_podman_env_args | default("") }}'
+  with_items: "{{ minio_podman_env }}"
+
 - name: Ensure required packages are installed
   package:
     name: "{{ minio_podman_packages }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for smlloyd.minio_podman
+minio_podman_env_args: ""


### PR DESCRIPTION
by way of using the new var `minio_podman_env` variable that takes a list:

```yaml
minio_podman_env:
  - MINIO_REGION_NAME=us-east-1
```

this will allow further customization of the minio instance as [outlined in the docs](https://docs.min.io/docs/minio-server-configuration-guide.html).