### PR TITLE
enable console by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Role Variables
 To use this role three variables should be set for the storage location and key/secret:
 
     minio_podman_data_dir: /srv/minio
-    minio_podman_key: CHANGEME
-    minio_podman_secret: CHANGEMECHANGEME
+    minio_podman_root_user: CHANGEME
+    minio_podman_root_password: CHANGEMECHANGEME
     minio_podman_env:
       - MINIO_REGION_NAME=us-east-1
 
@@ -33,6 +33,8 @@ Including an example of how to use your role (for instance, with variables passe
     - hosts: servers
       roles:
          - smlloyd.minio_podman
+           minio_podman_root_user: AKIAIOSFODNN7EXAMPLE
+           minio_podman_root_password: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ minio_podman_image_name: docker.io/minio/minio:latest
 minio_podman_image_tag: latest
 minio_podman_force_pull: False
 minio_podman_external_port: 9000
+minio_podman_console_port: 9001
 minio_podman_container_name: minio
 minio_podman_systemd_directory: /etc/systemd/system
 minio_podman_service: "container-{{ minio_podman_container_name }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,12 +10,14 @@
 
 - name: create container
   command: >-
-    podman run -d -p '{{ minio_podman_external_port }}':9000 --name '{{ minio_podman_container_name }}'
+    podman run -d --name '{{ minio_podman_container_name }}'
+    -p '{{ minio_podman_external_port }}':9000
+    -p '{{ minio_podman_console_port }}':9001
     -e "MINIO_ACCESS_KEY={{ minio_podman_key }}"
     -e "MINIO_SECRET_KEY={{ minio_podman_secret }}"
     {{ minio_podman_env_args }}
     -v '{{ minio_podman_data_dir }}:/data:Z'
-    "{{ minio_podman_image_name }}" server /data
+    "{{ minio_podman_image_name }}" server /data --console-address ":9001"
 
 
 - name: create systemd file

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,8 +13,8 @@
     podman run -d --name '{{ minio_podman_container_name }}'
     -p '{{ minio_podman_external_port }}':9000
     -p '{{ minio_podman_console_port }}':9001
-    -e "MINIO_ACCESS_KEY={{ minio_podman_key }}"
-    -e "MINIO_SECRET_KEY={{ minio_podman_secret }}"
+    -e "MINIO_ROOT_USER={{ minio_podman_root_user }}"
+    -e "MINIO_ROOT_PASSWORD={{ minio_podman_root_password }}"
     {{ minio_podman_env_args }}
     -v '{{ minio_podman_data_dir }}:/data:Z'
     "{{ minio_podman_image_name }}" server /data --console-address ":9001"


### PR DESCRIPTION
this will pin the embedded console server to port 9001 by default.

this pr breaks compatibility with older minio versions due to usage of the `--console-address` option which is part of the server distribution as of RELEASE.2021-07-08T01-15-01Z.

see https://docs.min.io/minio/baremetal/console/minio-console.html